### PR TITLE
Improve the filtering of ignored files

### DIFF
--- a/filesync.js
+++ b/filesync.js
@@ -138,12 +138,25 @@ class fileSync extends EventEmitter
 			}
 		}
 	}
+	escapeRegExp(string) {
+	  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
+	}
 	syncItem(itemPath, sync)
 	{
 		//if ignored, just continue along our merry way!
 		let ignoreDirs = [].concat((sync.ignore instanceof Array) ? sync.ignore : [sync.ignore]);
-		if((-1 !== itemPath.search(".git")) || (-1 !== ignoreDirs.indexOf(itemPath)))
-			return;
+	
+		if( itemPath ) {			
+			let regexString = ignoreDirs.map((str) => {
+			  return '(' + this.escapeRegExp(str) + ')';
+			}).join('|');
+			let regex = new RegExp(regexString);
+
+			if (regex.test(itemPath)) {
+			  this.emit("fsync_log", "syncItem", "itemPath excluded", itemPath);
+			  return;
+			}			
+		}
 
 		itemPath = paths.normalize(itemPath);//itemPath.replace(/\\/g, "/");
 		let srcPath = paths.normalize(`${sync.src}/${itemPath}`);


### PR DESCRIPTION
This will exclude files/directories that match any of the "ignore" keywords using regex, the previous implementation required an exact match (it used indexOf()) which made it impossible to exclude files by file extension, and it was very difficult to exclude subdirectories by name recursively because it only worked with the exact relative path.